### PR TITLE
Fix moneropool shaded build

### DIFF
--- a/moneropool/pom.xml
+++ b/moneropool/pom.xml
@@ -182,6 +182,16 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <transformers>
                         <transformer
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
Make maven-shade-plugin exclude all *.DSA, *.SF and *.RSA signature files