### PR TITLE
Add -fPIC to CXXFLAGS

### DIFF
--- a/moneropool/Makefile
+++ b/moneropool/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -std=c++11 -Wall -Wextra -O2
+CXXFLAGS = -std=c++11 -Wall -Wextra -O2 -fPIC
 CPPFLAGS = -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
 LDFLAGS = -shared
 LDLIBS = -lcryptonote_basic


### PR DESCRIPTION
Add -fPIC to CXXFLAGS to allow the native code to be built by clang as well as GCC.